### PR TITLE
Fix trimming PHPDoc prefix with TAB indent

### DIFF
--- a/framework/console/Controller.php
+++ b/framework/console/Controller.php
@@ -488,7 +488,7 @@ class Controller extends \yii\base\Controller
     {
         $docLines = preg_split('~\R~u', $reflection->getDocComment());
         if (isset($docLines[1])) {
-            return trim($docLines[1], ' *');
+            return trim($docLines[1], "\x09 *");
         }
         return '';
     }


### PR DESCRIPTION
When PHP code contains TAB characters for code indentation there was a bug with trimming PHPDoc signature. As a result `./yii help command` displays a list of sub-commands with " * " prefix in every sub-command description. This commit fixes this.